### PR TITLE
Fixed HugeArray to create direct references when free list is empty

### DIFF
--- a/lang/src/main/java/net/openhft/lang/collection/impl/HugeArrayImpl.java
+++ b/lang/src/main/java/net/openhft/lang/collection/impl/HugeArrayImpl.java
@@ -49,7 +49,7 @@ public class HugeArrayImpl<T> implements HugeArray<T> {
     }
 
     private T createRef() {
-        T ref = DataValueClasses.newInstance(tClass);
+        T ref = DataValueClasses.newDirectReference(tClass);
         ((Byteable) ref).bytes(store.createSlice(), 0L);
         return ref;
     }

--- a/lang/src/test/java/net/openhft/lang/collection/HugeArrayTest.java
+++ b/lang/src/test/java/net/openhft/lang/collection/HugeArrayTest.java
@@ -33,6 +33,28 @@ public class HugeArrayTest {
     }
 
     /*
+     * Test proves that you can get more than one object from the array
+     * The first object is created at construction time to get the size of an element
+     * The second one is created on the fly due to freelist being empty.
+     * There was a bug where acquire() was creating a heap object on freelist miss
+     */
+    @Test
+    public void testGetTwoObjects() {
+        HugeArray<JavaBeanInterface> array =
+                HugeCollections.newArray(JavaBeanInterface.class, 2);
+        JavaBeanInterface obj1 = array.get(0);
+        JavaBeanInterface obj2 = array.get(1);
+/*
+Can't call recycle due to recycle using .equals checks on your model.
+Two unmodified objects are .equals().
+Recycle should use identity to know if it's putting the same object back in the list.
+
+        array.recycle(obj1);
+        array.recycle(obj2);
+*/
+    }
+
+    /*
     With lock: false, average time to access a JavaBeanInterface was 71.9 ns
     With lock: true, average time to access a JavaBeanInterface was 124.7 ns
      */


### PR DESCRIPTION
HugeArrayImpl was creating heap objects and then casting to direct objects.
This made it impossible to have more than one outstanding reference to the array at a time.

Basically, you couldn't call:
array.get(0);
array.get(10);

that would crash on the 10 due to casting Heap objects to Direct objects.
