### PR TITLE
Make Java-Lang compatible with Java 6

### DIFF
--- a/lang/pom.xml
+++ b/lang/pom.xml
@@ -142,6 +142,15 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/lang/src/main/java/net/openhft/lang/io/serialization/impl/ListMarshaller.java
+++ b/lang/src/main/java/net/openhft/lang/io/serialization/impl/ListMarshaller.java
@@ -14,7 +14,7 @@ public class ListMarshaller<E> extends CollectionMarshaller<E, List<E>> implemen
     }
 
     public static <E> BytesMarshaller<List<E>> of(BytesMarshaller<E> eBytesMarshaller) {
-        return new ListMarshaller<>(eBytesMarshaller);
+        return new ListMarshaller<E>(eBytesMarshaller);
     }
 
     @Override
@@ -24,7 +24,7 @@ public class ListMarshaller<E> extends CollectionMarshaller<E, List<E>> implemen
 
     @Override
     List<E> newCollection() {
-        return new ArrayList<>();
+        return new ArrayList<E>();
     }
 
     @Override

--- a/lang/src/main/java/net/openhft/lang/io/serialization/impl/SetMarshaller.java
+++ b/lang/src/main/java/net/openhft/lang/io/serialization/impl/SetMarshaller.java
@@ -12,7 +12,7 @@ public class SetMarshaller<E> extends CollectionMarshaller<E, Set<E>> implements
     }
 
     public static <E> BytesMarshaller<Set<E>> of(BytesMarshaller<E> eBytesMarshaller) {
-        return new SetMarshaller<>(eBytesMarshaller);
+        return new SetMarshaller<E>(eBytesMarshaller);
     }
 
     @Override
@@ -22,7 +22,7 @@ public class SetMarshaller<E> extends CollectionMarshaller<E, Set<E>> implements
 
     @Override
     Set<E> newCollection() {
-        return new LinkedHashSet<>();
+        return new LinkedHashSet<E>();
     }
 
     @Override

--- a/lang/src/main/java/net/openhft/lang/io/serialization/impl/VanillaBytesMarshallerFactory.java
+++ b/lang/src/main/java/net/openhft/lang/io/serialization/impl/VanillaBytesMarshallerFactory.java
@@ -38,20 +38,20 @@ import static net.openhft.lang.io.serialization.CompactBytesMarshaller.*;
 public final class VanillaBytesMarshallerFactory implements BytesMarshallerFactory {
     private static final long serialVersionUID = 1L;
 
-    private transient Map<Class, BytesMarshaller> marshallerMap;
-    private transient BytesMarshaller[] compactMarshallerMap;
+    private transient Map<Class<?>, BytesMarshaller<?>> marshallerMap;
+    private transient BytesMarshaller<?>[] compactMarshallerMap;
 
     private void init() {
-        marshallerMap = new LinkedHashMap<>();
+        marshallerMap = new LinkedHashMap<Class<?>, BytesMarshaller<?>>();
         compactMarshallerMap = new BytesMarshaller[256];
-        BytesMarshaller stringMarshaller = new StringMarshaller(16 * 1024);
+        BytesMarshaller<String> stringMarshaller = new StringMarshaller(16 * 1024);
         addMarshaller(String.class, stringMarshaller);
-        addMarshaller(CharSequence.class, stringMarshaller);
+        addMarshaller(CharSequence.class, (BytesMarshaller)stringMarshaller);
         addMarshaller(Class.class, new ClassMarshaller(Thread.currentThread().getContextClassLoader()));
         addMarshaller(Date.class, new DateMarshaller(10191));
-        addMarshaller(Integer.class, new CompactEnumBytesMarshaller<>(Integer.class, 10191, INT_CODE));
-        addMarshaller(Long.class, new CompactEnumBytesMarshaller<>(Long.class, 10191, LONG_CODE));
-        addMarshaller(Double.class, new CompactEnumBytesMarshaller<>(Double.class, 10191, DOUBLE_CODE));
+        addMarshaller(Integer.class, new CompactEnumBytesMarshaller<Integer>(Integer.class, 10191, INT_CODE));
+        addMarshaller(Long.class, new CompactEnumBytesMarshaller<Long>(Long.class, 10191, LONG_CODE));
+        addMarshaller(Double.class, new CompactEnumBytesMarshaller<Double>(Double.class, 10191, DOUBLE_CODE));
         addMarshaller(ByteBuffer.class, ByteBufferMarshaller.INSTANCE);
     }
 
@@ -79,9 +79,10 @@ public final class VanillaBytesMarshallerFactory implements BytesMarshallerFacto
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <E> BytesMarshaller<E> getMarshaller(byte code) {
         if (marshallerMap == null) init();
-        return compactMarshallerMap[code & 0xFF];
+        return (BytesMarshaller<E>) compactMarshallerMap[code & 0xFF];
     }
 
     public <E> void addMarshaller(Class<E> eClass, BytesMarshaller<E> marshaller) {

--- a/lang/src/test/java/net/openhft/lang/io/PingPongMain.java
+++ b/lang/src/test/java/net/openhft/lang/io/PingPongMain.java
@@ -60,7 +60,7 @@ public class PingPongMain {
     private static void startServer() throws IOException {
         ServerSocketChannel ssc = ServerSocketChannel.open();
         ssc.socket().setReuseAddress(true);
-        ssc.bind(new InetSocketAddress(PORT));
+        ssc.socket().bind(new InetSocketAddress(PORT));
 
         System.out.println("Listening for one connection on port " + PORT);
         SocketChannel sc = ssc.accept();

--- a/lang/src/test/java/net/openhft/lang/io/serialization/impl/SnappyStringMarshallerTest.java
+++ b/lang/src/test/java/net/openhft/lang/io/serialization/impl/SnappyStringMarshallerTest.java
@@ -2,9 +2,10 @@ package net.openhft.lang.io.serialization.impl;
 
 import net.openhft.lang.io.Bytes;
 import net.openhft.lang.io.DirectStore;
+
 import org.junit.Test;
 
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
@@ -22,7 +23,7 @@ public class SnappyStringMarshallerTest {
         Random random = new Random();
         for (int i = 0; i < bytes.length; i++)
             bytes[i] = (byte) ('A' + random.nextInt(26));
-        testWriteRead(b, new String(bytes, StandardCharsets.ISO_8859_1));
+        testWriteRead(b, new String(bytes, Charset.forName("ISO-8859-1")));
     }
 
     private void testWriteRead(Bytes b, String s) {

--- a/lang/src/test/java/net/openhft/lang/io/serialization/impl/StringZMapMarshallerTest.java
+++ b/lang/src/test/java/net/openhft/lang/io/serialization/impl/StringZMapMarshallerTest.java
@@ -31,7 +31,7 @@ public class StringZMapMarshallerTest {
     }
 
     public static <K, V> Map<K, V> mapOf(K k, V v, Object... keysAndValues) {
-        Map<K, V> ret = new LinkedHashMap<>();
+        Map<K, V> ret = new LinkedHashMap<K, V>();
         ret.put(k, v);
         for (int i = 0; i < keysAndValues.length - 1; i += 2) {
             Object key = keysAndValues[i];


### PR DESCRIPTION
- Configure the compiler to emit Java 6 bytecode (unfortunately this means that Java 7 features like the diamond operator can not be used)
- Add alternative code-paths for cases where the field names have changed betwee Java 6/7

This has been tested and all the unittest pass with Java 6, 7 and 8.
