### PR TITLE
Try to ensure that changes to mmapped files are written back before MappedStore.close returns

### DIFF
--- a/lang/src/main/java/net/openhft/lang/io/MappedStore.java
+++ b/lang/src/main/java/net/openhft/lang/io/MappedStore.java
@@ -187,6 +187,7 @@ public class MappedStore implements BytesStore, Closeable {
                 address = 0;
 
                 if (channel.isOpen()) {
+                    channel.force(true);
                     channel.close();
                 }
             } catch (IOException e) {


### PR DESCRIPTION
This is a speculative fix for NFS. The NFS FAQ says (see http://nfs.sourceforge.net/ - section D8) that closing a file is not enough to guarantee even close-to-open cache coherency and one needs to call msync(MS_SYNC) to achieve that. Currently the only way to do that under Java is to call FileChannel.force.