### PR TITLE
Add a version of MappedStore which can be resized

### DIFF
--- a/lang-sandbox/pom.xml
+++ b/lang-sandbox/pom.xml
@@ -29,7 +29,7 @@
     <name>OpenHFT/Java-Lang/lang-sandbox</name>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>lang-sandbox</artifactId>
-    <version>6.5.2-SNAPSHOT</version>
+    <version>6.6.12-SNAPSHOT</version>
 
     <dependencyManagement>
         <dependencies>
@@ -37,7 +37,7 @@
                 <groupId>net.openhft</groupId>
                 <artifactId>third-party-bom</artifactId>
                 <type>pom</type>
-                <version>3.4.6</version>
+                <version>3.4.20</version>
                 <scope>import</scope>
             </dependency>
             <dependency>

--- a/lang-test/pom.xml
+++ b/lang-test/pom.xml
@@ -57,7 +57,7 @@
             <dependency>
                 <groupId>net.openhft</groupId>
                 <artifactId>affinity</artifactId>
-                <version>2.2</version>
+                <version>3.0</version>
             </dependency>
             <dependency>
                 <groupId>net.openhft</groupId>

--- a/lang-test/pom.xml
+++ b/lang-test/pom.xml
@@ -29,7 +29,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>lang-test</artifactId>
-    <version>6.6.10-SNAPSHOT</version>
+    <version>6.6.12-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>OpenHFT/Java-Lang/lang-test</name>
@@ -41,7 +41,7 @@
                 <groupId>net.openhft</groupId>
                 <artifactId>third-party-bom</artifactId>
                 <type>pom</type>
-                <version>3.4.18</version>
+                <version>3.4.20</version>
                 <scope>import</scope>
             </dependency>
             <dependency>

--- a/lang-test/pom.xml
+++ b/lang-test/pom.xml
@@ -29,7 +29,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>lang-test</artifactId>
-    <version>6.6.12-SNAPSHOT</version>
+    <version>6.6.13-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>OpenHFT/Java-Lang/lang-test</name>
@@ -47,7 +47,7 @@
             <dependency>
                 <groupId>net.openhft</groupId>
                 <artifactId>lang</artifactId>
-                <version>${project.version}</version>
+                <version>6.6.12</version>
             </dependency>
             <dependency>
                 <groupId>net.openhft</groupId>

--- a/lang-test/src/main/java/net/openhft/lang/io/LockingViaMMapWithThreadIdMain.java
+++ b/lang-test/src/main/java/net/openhft/lang/io/LockingViaMMapWithThreadIdMain.java
@@ -16,7 +16,7 @@
 
 package net.openhft.lang.io;
 
-import net.openhft.affinity.AffinitySupport;
+import net.openhft.affinity.Affinity;
 
 import java.io.File;
 import java.io.IOException;
@@ -50,8 +50,7 @@ public class LockingViaMMapWithThreadIdMain {
         MappedByteBuffer mbb = fc.map(FileChannel.MapMode.READ_WRITE, 0, RECORDS * RECORD_SIZE);
         // set the the Thread.getId() to match the process thread id
         // this way the getId() can be used across processes..
-        AffinitySupport.setThreadId();
-        AffinitySupport.setAffinity(toggleTo ? 1 << 3 : 1 << 2);
+        Affinity.setAffinity(toggleTo ? 1 << 3 : 1 << 2);
         Bytes bytes = ByteBufferBytes.wrap(mbb);
 
         long start = 0;

--- a/lang/pom.xml
+++ b/lang/pom.xml
@@ -26,7 +26,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>lang</artifactId>
-    <version>6.6.11-SNAPSHOT</version>
+    <version>6.6.11</version>
     <packaging>bundle</packaging>
     <name>OpenHFT/Java-Lang/lang</name>
     <description>Java Lang library for High Frequency Trading (Java 6+)</description>
@@ -194,7 +194,7 @@
         <url>scm:git:git@github.com:OpenHFT/Java-Lang.git</url>
         <connection>scm:git:git@github.com:OpenHFT/Java-Lang.git</connection>
         <developerConnection>scm:git:git@github.com:OpenHFT/Java-Lang.git</developerConnection>
-        <tag>master</tag>
+        <tag>lang-6.6.11</tag>
     </scm>
 
 </project>

--- a/lang/pom.xml
+++ b/lang/pom.xml
@@ -26,7 +26,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>lang</artifactId>
-    <version>6.6.11</version>
+    <version>6.6.12-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>OpenHFT/Java-Lang/lang</name>
     <description>Java Lang library for High Frequency Trading (Java 6+)</description>
@@ -194,7 +194,7 @@
         <url>scm:git:git@github.com:OpenHFT/Java-Lang.git</url>
         <connection>scm:git:git@github.com:OpenHFT/Java-Lang.git</connection>
         <developerConnection>scm:git:git@github.com:OpenHFT/Java-Lang.git</developerConnection>
-        <tag>lang-6.6.11</tag>
+        <tag>master</tag>
     </scm>
 
 </project>

--- a/lang/pom.xml
+++ b/lang/pom.xml
@@ -37,7 +37,7 @@
                 <groupId>net.openhft</groupId>
                 <artifactId>third-party-bom</artifactId>
                 <type>pom</type>
-                <version>3.4.18</version>
+                <version>3.4.20</version>
                 <scope>import</scope>
             </dependency>
 

--- a/lang/pom.xml
+++ b/lang/pom.xml
@@ -26,7 +26,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>lang</artifactId>
-    <version>6.6.12-SNAPSHOT</version>
+    <version>6.6.12</version>
     <packaging>bundle</packaging>
     <name>OpenHFT/Java-Lang/lang</name>
     <description>Java Lang library for High Frequency Trading (Java 6+)</description>
@@ -194,7 +194,7 @@
         <url>scm:git:git@github.com:OpenHFT/Java-Lang.git</url>
         <connection>scm:git:git@github.com:OpenHFT/Java-Lang.git</connection>
         <developerConnection>scm:git:git@github.com:OpenHFT/Java-Lang.git</developerConnection>
-        <tag>master</tag>
+        <tag>lang-6.6.12</tag>
     </scm>
 
 </project>

--- a/lang/pom.xml
+++ b/lang/pom.xml
@@ -26,7 +26,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>lang</artifactId>
-    <version>6.6.12</version>
+    <version>6.6.13-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>OpenHFT/Java-Lang/lang</name>
     <description>Java Lang library for High Frequency Trading (Java 6+)</description>
@@ -194,7 +194,7 @@
         <url>scm:git:git@github.com:OpenHFT/Java-Lang.git</url>
         <connection>scm:git:git@github.com:OpenHFT/Java-Lang.git</connection>
         <developerConnection>scm:git:git@github.com:OpenHFT/Java-Lang.git</developerConnection>
-        <tag>lang-6.6.12</tag>
+        <tag>master</tag>
     </scm>
 
 </project>

--- a/lang/src/main/java/net/openhft/lang/io/AbstractMappedStore.java
+++ b/lang/src/main/java/net/openhft/lang/io/AbstractMappedStore.java
@@ -1,0 +1,225 @@
+/*
+ *     Copyright (C) 2015  higherfrequencytrading.com
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.openhft.lang.io;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.channels.FileChannel;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import net.openhft.lang.io.serialization.ObjectSerializer;
+import net.openhft.lang.model.constraints.NotNull;
+import sun.misc.Cleaner;
+import sun.nio.ch.FileChannelImpl;
+
+abstract class AbstractMappedStore implements BytesStore, Closeable {
+    private static final int MAP_RO = 0;
+    private static final int MAP_RW = 1;
+    private static final int MAP_PV = 2;
+
+    // retain to prevent GC.
+    private final File file;
+    private final RandomAccessFile raf;
+    private final Cleaner cleaner;
+    private final AtomicInteger refCount = new AtomicInteger(1);
+    private final FileChannel.MapMode mode;
+    protected final MmapInfoHolder mmapInfoHolder;
+    private ObjectSerializer objectSerializer;
+
+    AbstractMappedStore(MmapInfoHolder mmapInfoHolder, File file, FileChannel.MapMode mode, long size, ObjectSerializer objectSerializer) throws IOException {
+        validateSize(size);
+        this.file = file;
+        this.mmapInfoHolder = mmapInfoHolder;
+        this.mmapInfoHolder.setSize(size);
+        this.objectSerializer = objectSerializer;
+        this.mode = mode;
+
+        try {
+            this.raf = new RandomAccessFile(file, accesModeFor(mode));
+            resizeIfNeeded(size);
+            map();
+            this.cleaner = Cleaner.create(this, new Unmapper(mmapInfoHolder, raf));
+        } catch (Exception e) {
+            throw wrap(e);
+        }
+    }
+
+    protected final void validateSize(long size) {
+        if (size <= 0 || size > 128L << 40) {
+            throw new IllegalArgumentException("invalid size: " + size);
+        }
+    }
+
+    protected final void resizeIfNeeded(long newSize) throws IOException {
+        if (raf.length() == newSize) {
+            return;
+        }
+        if (file.getAbsolutePath().startsWith("/dev/")) {
+            return;
+        }
+        if (mode != FileChannel.MapMode.READ_WRITE) {
+            throw new IOException("Cannot resize file to " + newSize + " as mode is not READ_WRITE");
+        }
+
+        raf.setLength(newSize);
+    }
+
+    protected final void map() throws IOException {
+        try {
+            mmapInfoHolder.setAddress(map0(raf.getChannel(), imodeFor(mode), 0L, mmapInfoHolder.getSize()));
+        } catch (Exception e) {
+            throw wrap(e);
+        }
+    }
+
+    protected final void unmapAndSyncToDisk() throws IOException {
+        unmap0(mmapInfoHolder.getAddress(), mmapInfoHolder.getSize());
+        raf.getChannel().force(true);
+    }
+
+    private static long map0(FileChannel fileChannel, int imode, long start, long size) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        Method map0 = fileChannel.getClass().getDeclaredMethod("map0", int.class, long.class, long.class);
+        map0.setAccessible(true);
+        return (Long) map0.invoke(fileChannel, imode, start, size);
+    }
+
+    private static void unmap0(long address, long size) throws IOException {
+        try {
+            Method unmap0 = FileChannelImpl.class.getDeclaredMethod("unmap0", long.class, long.class);
+            unmap0.setAccessible(true);
+            unmap0.invoke(null, address, size);
+        } catch (Exception e) {
+            throw wrap(e);
+        }
+    }
+
+    private static IOException wrap(Throwable e) {
+        if (e instanceof InvocationTargetException)
+            e = e.getCause();
+        if (e instanceof IOException)
+            return (IOException) e;
+        return new IOException(e);
+    }
+
+    private static String accesModeFor(FileChannel.MapMode mode) {
+        return mode == FileChannel.MapMode.READ_WRITE ? "rw" : "r";
+    }
+
+    private static int imodeFor(FileChannel.MapMode mode) {
+        int imode = -1;
+        if (mode == FileChannel.MapMode.READ_ONLY)
+            imode = MAP_RO;
+        else if (mode == FileChannel.MapMode.READ_WRITE)
+            imode = MAP_RW;
+        else if (mode == FileChannel.MapMode.PRIVATE)
+            imode = MAP_PV;
+        assert (imode >= 0);
+        return imode;
+    }
+
+    @Override
+    public final ObjectSerializer objectSerializer() {
+        return objectSerializer;
+    }
+
+    @Override
+    public final long address() {
+        return mmapInfoHolder.getAddress();
+    }
+
+    @Override
+    public final long size() {
+        return mmapInfoHolder.getSize();
+    }
+
+    @Override
+    public final  void free() {
+        cleaner.clean();
+    }
+
+    @Override
+    public final  void close() {
+        free();
+    }
+
+    @NotNull
+    public final  DirectBytes bytes() {
+        return new DirectBytes(this, refCount);
+    }
+
+    @NotNull
+    public final  DirectBytes bytes(long offset, long length) {
+        return new DirectBytes(this, refCount, offset, length);
+    }
+
+    public final  File file() {
+        return file;
+    }
+
+    abstract static class MmapInfoHolder {
+        abstract void setAddress(long address);
+
+        abstract long getAddress();
+
+        abstract void setSize(long size);
+
+        abstract long getSize();
+    }
+
+    private static final class Unmapper implements Runnable {
+        private final MmapInfoHolder mmapInfoHolder;
+        private final RandomAccessFile raf;
+        /*
+         * This is not for synchronization (since calling this from multiple
+         * threads through .free / .close is an user error!) but rather to make
+         * sure that if an explicit cleanup was performed, the cleaner does not
+         * retry cleaning up the resources.
+         */
+        private volatile boolean cleanedUp;
+
+        Unmapper(MmapInfoHolder mmapInfo, RandomAccessFile raf) {
+            this.mmapInfoHolder = mmapInfo;
+            this.raf = raf;
+        }
+
+        public void run() {
+            if (cleanedUp) {
+                return;
+            }
+            cleanedUp = true;
+
+            try {
+                unmap0(mmapInfoHolder.getAddress(), mmapInfoHolder.getSize());
+                raf.getChannel().force(true);
+                // this also closes the underlying channel as per the documentation
+                raf.close();
+            } catch (IOException e) {
+                UnmapperLoggerHolder.LOGGER.log(Level.SEVERE,
+                    "An exception has occurred while cleaning up a MappedStore instance: " + e.getMessage(), e);
+            }
+        }
+    }
+
+    private static final class UnmapperLoggerHolder {
+        private static final Logger LOGGER = Logger.getLogger(Unmapper.class.getName());
+    }
+}

--- a/lang/src/main/java/net/openhft/lang/io/DirectByteBufferBytes.java
+++ b/lang/src/main/java/net/openhft/lang/io/DirectByteBufferBytes.java
@@ -64,8 +64,7 @@ public class DirectByteBufferBytes extends NativeBytes implements IByteBufferByt
             }
 
             this.buffer = ByteBuffer.allocateDirect(newCapacity).order(ByteOrder.nativeOrder());
-            this.startAddr = ((DirectBuffer) buffer).address();
-            this.positionAddr = this.startAddr;
+            setStartPositionAddress(((DirectBuffer) buffer).address());
             this.capacityAddr = this.startAddr + newCapacity;
             this.limitAddr = this.capacityAddr;
 

--- a/lang/src/main/java/net/openhft/lang/io/DirectBytes.java
+++ b/lang/src/main/java/net/openhft/lang/io/DirectBytes.java
@@ -42,7 +42,7 @@ public class DirectBytes extends NativeBytes {
         if (offset < 0 || size < 0 || offset + size > store.size())
             throw new IllegalArgumentException();
 
-        startAddr = positionAddr = store.address() + offset;
+        setStartPositionAddress(store.address() + offset);
         capacityAddr = limitAddr = startAddr + size;
     }
 

--- a/lang/src/main/java/net/openhft/lang/io/IOTools.java
+++ b/lang/src/main/java/net/openhft/lang/io/IOTools.java
@@ -25,10 +25,8 @@ import sun.nio.ch.DirectBuffer;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
-import java.util.Random;
 
 /**
  * @author peter.lawrey
@@ -88,19 +86,5 @@ public enum IOTools {
             if (cl != null)
                 cl.clean();
         }
-    }
-
-    public static int freePort() {
-        int min = 48000, max = 65535;
-        Random rand = new Random();
-        for (int i = 0; i < 10; i++) {
-            int port = rand.nextInt(max - min + 1) + min;
-            try {
-                new Socket("localhost", port).close();
-            } catch (IOException e) {
-                return port;
-            }
-        }
-        throw new IllegalStateException("Unable to find a random free port");
     }
 }

--- a/lang/src/main/java/net/openhft/lang/io/MappedStore.java
+++ b/lang/src/main/java/net/openhft/lang/io/MappedStore.java
@@ -32,50 +32,21 @@ public class MappedStore extends AbstractMappedStore {
     }
 
     @Deprecated
-    public MappedStore(File file, FileChannel.MapMode mode, long size, BytesMarshallerFactory bytesMarshallerFactory) throws IOException {
-        this(file, mode, size, BytesMarshallableSerializer.create(bytesMarshallerFactory, JDKZObjectSerializer.INSTANCE));
+    public MappedStore(File file, FileChannel.MapMode mode, long size,
+            BytesMarshallerFactory bytesMarshallerFactory) throws IOException {
+        this(file, mode, size, BytesMarshallableSerializer.create(
+                bytesMarshallerFactory, JDKZObjectSerializer.INSTANCE));
     }
 
-    public MappedStore(File file, FileChannel.MapMode mode, long size, ObjectSerializer objectSerializer) throws IOException {
-        super(new ReadOnlyMmapInfoHolder(), file, mode, size, objectSerializer);
-        ((ReadOnlyMmapInfoHolder)mmapInfoHolder).lock();
+    public MappedStore(File file, FileChannel.MapMode mode, long size,
+            ObjectSerializer objectSerializer) throws IOException {
+        this(file, mode, 0L, size, objectSerializer);
     }
 
-    private static final class ReadOnlyMmapInfoHolder extends MmapInfoHolder {
-        private long address, size;
-        private boolean locked;
-
-        private void checkLock() {
-            if (locked) {
-                throw new IllegalStateException();
-            }
-        }
-
-        void lock() {
-            this.locked = true;
-        }
-
-        @Override
-        void setAddress(long address) {
-            checkLock();
-            this.address = address;
-        }
-
-        @Override
-        long getAddress() {
-            return address;
-        }
-
-        @Override
-        void setSize(long size) {
-            checkLock();
-            this.size = size;
-        }
-
-        @Override
-        long getSize() {
-            return size;
-        }
+    public MappedStore(File file, FileChannel.MapMode mode, long startInFile, long size,
+            ObjectSerializer objectSerializer) throws IOException {
+        super(new MmapInfoHolder(), file, mode, startInFile, size, objectSerializer);
+        mmapInfoHolder.lock();
     }
 }
 

--- a/lang/src/main/java/net/openhft/lang/io/MappedStore.java
+++ b/lang/src/main/java/net/openhft/lang/io/MappedStore.java
@@ -33,6 +33,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.channels.FileChannel;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class MappedStore implements BytesStore, Closeable {
 
@@ -164,9 +166,15 @@ public class MappedStore implements BytesStore, Closeable {
         return file;
     }
 
-    static class Unmapper implements Runnable {
+    private static final class Unmapper implements Runnable {
         private final long size;
         private final FileChannel channel;
+        /*
+         * This is not for synchronization (since calling this from multiple
+         * threads through .free / .close is an user error!) but rather to make
+         * sure that if an explicit cleanup was performed, the cleaner does not
+         * retry cleaning up the resources.
+         */
         private volatile long address;
 
         Unmapper(long address, long size, FileChannel channel) {
@@ -184,13 +192,16 @@ public class MappedStore implements BytesStore, Closeable {
                 unmap0(address, size);
                 address = 0;
 
-                if (channel.isOpen()) {
-                    channel.force(true);
-                    channel.close();
-                }
+                channel.force(true);
+                channel.close();
             } catch (IOException e) {
-                e.printStackTrace();
+                UnmapperLoggerHolder.LOGGER.log(Level.SEVERE,
+                    "An exception has occurred while cleaning up a MappedStore instance: " + e.getMessage(), e);
             }
+        }
+
+        private static final class UnmapperLoggerHolder {
+            private static final Logger LOGGER = Logger.getLogger(Unmapper.class.getName());
         }
     }
 }

--- a/lang/src/main/java/net/openhft/lang/io/MultiStoreBytes.java
+++ b/lang/src/main/java/net/openhft/lang/io/MultiStoreBytes.java
@@ -29,7 +29,7 @@ public class MultiStoreBytes extends NativeBytes {
             throw new IllegalArgumentException("offset: " + offset + ", size: " + size + ", store.size: " + store.size());
         setObjectSerializer(store.objectSerializer());
 
-        startAddr = positionAddr = store.address() + offset;
+        setStartPositionAddress(store.address() + offset);
         capacityAddr = limitAddr = startAddr + size;
         underlyingBytes = null;
         underlyingOffset = 0;
@@ -39,7 +39,7 @@ public class MultiStoreBytes extends NativeBytes {
         setObjectSerializer(bytes.objectSerializer());
 
         long bytesAddr = bytes.address();
-        startAddr = positionAddr = bytesAddr + offset;
+        setStartPositionAddress(bytesAddr + offset);
         capacityAddr = limitAddr = bytesAddr + bytes.capacity();
         underlyingBytes = bytes;
         underlyingOffset = offset;

--- a/lang/src/main/java/net/openhft/lang/io/NativeBytes.java
+++ b/lang/src/main/java/net/openhft/lang/io/NativeBytes.java
@@ -64,12 +64,19 @@ public class NativeBytes extends AbstractBytes {
 
     public NativeBytes(long startAddr, long capacityAddr) {
         super();
-
-        this.positionAddr =
-                this.startAddr = startAddr;
+        setStartPositionAddress(startAddr);
+        if (startAddr > capacityAddr)
+            throw new IllegalArgumentException("Missorted capacity address");
         this.limitAddr =
                 this.capacityAddr = capacityAddr;
         positionChecks(positionAddr);
+    }
+
+    public void setStartPositionAddress(long startAddr) {
+        if ((startAddr & ~0x3fff) == 0)
+            throw new AssertionError("Invalid address " + Long.toHexString(startAddr));
+        this.positionAddr =
+                this.startAddr = startAddr;
     }
 
     public static NativeBytes wrap(long address, long capacity) {
@@ -84,8 +91,7 @@ public class NativeBytes extends AbstractBytes {
                        long startAddr, long capacityAddr, AtomicInteger refCount) {
         super(bytesMarshallerFactory, refCount);
 
-        this.positionAddr =
-                this.startAddr = startAddr;
+        setStartPositionAddress(startAddr);
         this.limitAddr =
                 this.capacityAddr = capacityAddr;
         positionChecks(positionAddr);
@@ -95,8 +101,7 @@ public class NativeBytes extends AbstractBytes {
                        long startAddr, long capacityAddr, AtomicInteger refCount) {
         super(objectSerializer, refCount);
 
-        this.positionAddr =
-                this.startAddr = startAddr;
+        setStartPositionAddress(startAddr);
         this.limitAddr =
                 this.capacityAddr = capacityAddr;
         positionChecks(positionAddr);
@@ -104,7 +109,7 @@ public class NativeBytes extends AbstractBytes {
 
     public NativeBytes(NativeBytes bytes) {
         super(bytes.objectSerializer(), new AtomicInteger(1));
-        this.startAddr = bytes.startAddr;
+        setStartPositionAddress(bytes.startAddr);
 
         this.positionAddr = bytes.positionAddr;
         this.limitAddr = bytes.limitAddr;
@@ -139,6 +144,7 @@ public class NativeBytes extends AbstractBytes {
             appendable.append((char) c);
         }
     }
+
     @Override
     public NativeBytes slice() {
         return new NativeBytes(objectSerializer(), positionAddr, limitAddr, refCount);
@@ -762,7 +768,7 @@ public class NativeBytes extends AbstractBytes {
     }
 
     void address(long address) {
-        this.positionAddr = this.startAddr = address;
+        setStartPositionAddress(address);
     }
 
     void capacity(long capacity) {

--- a/lang/src/main/java/net/openhft/lang/io/ResizableMappedStore.java
+++ b/lang/src/main/java/net/openhft/lang/io/ResizableMappedStore.java
@@ -13,51 +13,50 @@
  *     You should have received a copy of the GNU Lesser General Public License
  *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 package net.openhft.lang.io;
-
-import net.openhft.lang.io.serialization.BytesMarshallableSerializer;
-import net.openhft.lang.io.serialization.BytesMarshallerFactory;
-import net.openhft.lang.io.serialization.JDKZObjectSerializer;
-import net.openhft.lang.io.serialization.ObjectSerializer;
-import net.openhft.lang.io.serialization.impl.VanillaBytesMarshallerFactory;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 
-public class MappedStore extends AbstractMappedStore {
-    public MappedStore(File file, FileChannel.MapMode mode, long size) throws IOException {
-        this(file, mode, size, new VanillaBytesMarshallerFactory());
+import net.openhft.lang.io.serialization.BytesMarshallableSerializer;
+import net.openhft.lang.io.serialization.JDKZObjectSerializer;
+import net.openhft.lang.io.serialization.ObjectSerializer;
+import net.openhft.lang.io.serialization.impl.VanillaBytesMarshallerFactory;
+
+public final class ResizableMappedStore extends AbstractMappedStore {
+    public ResizableMappedStore(File file, FileChannel.MapMode mode, long size) throws IOException {
+        this(file, mode, size, BytesMarshallableSerializer.create(new VanillaBytesMarshallerFactory(), JDKZObjectSerializer.INSTANCE));
     }
 
-    @Deprecated
-    public MappedStore(File file, FileChannel.MapMode mode, long size, BytesMarshallerFactory bytesMarshallerFactory) throws IOException {
-        this(file, mode, size, BytesMarshallableSerializer.create(bytesMarshallerFactory, JDKZObjectSerializer.INSTANCE));
+    public ResizableMappedStore(File file, FileChannel.MapMode mode, long size, ObjectSerializer objectSerializer) throws IOException {
+        super(new ReadWriteMmapInfoHolder(), file, mode, size, objectSerializer);
     }
 
-    public MappedStore(File file, FileChannel.MapMode mode, long size, ObjectSerializer objectSerializer) throws IOException {
-        super(new ReadOnlyMmapInfoHolder(), file, mode, size, objectSerializer);
-        ((ReadOnlyMmapInfoHolder)mmapInfoHolder).lock();
+
+    /**
+     * Resizes the underlying file and re-maps it. Warning! After this call
+     * instances of {@link Bytes} obtained through {@link #bytes()} or
+     * {@link #bytes(long, long)} are invalid and using them can lead to reading
+     * arbitrary data or JVM crash! It is the callers responsibility to ensure
+     * that these instances are not used after the method call.
+     * 
+     * @param newSize
+     * @throws IOException
+     */
+    public void resize(long newSize) throws IOException {
+        validateSize(newSize);
+        unmapAndSyncToDisk();
+        resizeIfNeeded(newSize);
+        this.mmapInfoHolder.setSize(newSize);
+        map();
     }
 
-    private static final class ReadOnlyMmapInfoHolder extends MmapInfoHolder {
+    private static final class ReadWriteMmapInfoHolder extends MmapInfoHolder {
         private long address, size;
-        private boolean locked;
-
-        private void checkLock() {
-            if (locked) {
-                throw new IllegalStateException();
-            }
-        }
-
-        void lock() {
-            this.locked = true;
-        }
 
         @Override
         void setAddress(long address) {
-            checkLock();
             this.address = address;
         }
 
@@ -68,7 +67,6 @@ public class MappedStore extends AbstractMappedStore {
 
         @Override
         void setSize(long size) {
-            checkLock();
             this.size = size;
         }
 
@@ -78,4 +76,3 @@ public class MappedStore extends AbstractMappedStore {
         }
     }
 }
-

--- a/lang/src/main/java/net/openhft/lang/io/ResizeableMappedStore.java
+++ b/lang/src/main/java/net/openhft/lang/io/ResizeableMappedStore.java
@@ -1,0 +1,54 @@
+/*
+ *     Copyright (C) 2015  higherfrequencytrading.com
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.openhft.lang.io;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+
+import net.openhft.lang.io.serialization.BytesMarshallableSerializer;
+import net.openhft.lang.io.serialization.JDKZObjectSerializer;
+import net.openhft.lang.io.serialization.ObjectSerializer;
+import net.openhft.lang.io.serialization.impl.VanillaBytesMarshallerFactory;
+
+public final class ResizeableMappedStore extends AbstractMappedStore {
+    public ResizeableMappedStore(File file, FileChannel.MapMode mode, long size) throws IOException {
+        this(file, mode, size, BytesMarshallableSerializer.create(new VanillaBytesMarshallerFactory(), JDKZObjectSerializer.INSTANCE));
+    }
+
+    public ResizeableMappedStore(File file, FileChannel.MapMode mode, long size, ObjectSerializer objectSerializer) throws IOException {
+        super(new MmapInfoHolder(), file, mode, 0L, size, objectSerializer);
+    }
+
+
+    /**
+     * Resizes the underlying file and re-maps it. Warning! After this call
+     * instances of {@link Bytes} obtained through {@link #bytes()} or
+     * {@link #bytes(long, long)} are invalid and using them can lead to reading
+     * arbitrary data or JVM crash! It is the callers responsibility to ensure
+     * that these instances are not used after the method call.
+     * 
+     * @param newSize
+     * @throws IOException
+     */
+    public void resize(long newSize) throws IOException {
+        validateSize(newSize);
+        unmapAndSyncToDisk();
+        resizeIfNeeded(0L, newSize);
+        this.mmapInfoHolder.setSize(newSize);
+        map(0L);
+    }
+}

--- a/lang/src/main/java/net/openhft/lang/io/VanillaMappedBytes.java
+++ b/lang/src/main/java/net/openhft/lang/io/VanillaMappedBytes.java
@@ -39,8 +39,8 @@ public class VanillaMappedBytes extends NativeBytes {
 
     protected VanillaMappedBytes(final MappedByteBuffer buffer, long index, final FileChannel channel) {
         super(
-            ((DirectBuffer)buffer).address(),
-            ((DirectBuffer)buffer).address() + buffer.capacity()
+                buffer.capacity() == 0 ? NO_PAGE : ((DirectBuffer) buffer).address(),
+                buffer.capacity() == 0 ? NO_PAGE : ((DirectBuffer) buffer).address() + buffer.capacity()
         );
 
         this.buffer = buffer;

--- a/lang/src/main/java/net/openhft/lang/io/serialization/impl/BytesMarshallableMarshaller.java
+++ b/lang/src/main/java/net/openhft/lang/io/serialization/impl/BytesMarshallableMarshaller.java
@@ -66,7 +66,7 @@ public class BytesMarshallableMarshaller<E extends BytesMarshallable>
 
     @SuppressWarnings("unchecked")
     @NotNull
-    protected E getInstance() throws InstantiationException {
+    protected E getInstance() throws Exception {
         return (E) NativeBytes.UNSAFE.allocateInstance(classMarshaled);
     }
 

--- a/lang/src/main/java/net/openhft/lang/io/serialization/impl/ExternalizableMarshaller.java
+++ b/lang/src/main/java/net/openhft/lang/io/serialization/impl/ExternalizableMarshaller.java
@@ -71,7 +71,7 @@ public class ExternalizableMarshaller<E extends Externalizable> implements Bytes
 
     @SuppressWarnings("unchecked")
     @NotNull
-    protected E getInstance() throws InstantiationException {
+    protected E getInstance() throws Exception {
         return (E) NativeBytes.UNSAFE.allocateInstance(classMarshaled);
     }
 

--- a/lang/src/test/java/net/openhft/lang/io/ByteBufferBytesTest.java
+++ b/lang/src/test/java/net/openhft/lang/io/ByteBufferBytesTest.java
@@ -112,12 +112,6 @@ public class ByteBufferBytesTest {
     }
 
     @Test
-    public void testCapacity()   {
-        assertEquals(SIZE, bytes.capacity());
-        assertEquals(10, new NativeBytes(0, 10).capacity());
-    }
-
-    @Test
     public void testRemaining()   {
         assertEquals(SIZE, bytes.remaining());
         bytes.position(10);

--- a/lang/src/test/java/net/openhft/lang/io/DirectByteBufferBytesTest.java
+++ b/lang/src/test/java/net/openhft/lang/io/DirectByteBufferBytesTest.java
@@ -103,12 +103,6 @@ public class DirectByteBufferBytesTest {
     }
 
     @Test
-    public void testCapacity()   {
-        assertEquals(SIZE, bytes.capacity());
-        assertEquals(10, new NativeBytes(0, 10).capacity());
-    }
-
-    @Test
     public void testRemaining()   {
         assertEquals(SIZE, bytes.remaining());
         bytes.position(10);

--- a/lang/src/test/java/net/openhft/lang/io/MappedStoreTest.java
+++ b/lang/src/test/java/net/openhft/lang/io/MappedStoreTest.java
@@ -51,7 +51,7 @@ public class MappedStoreTest {
 
         slice.release();
 
-        ms.free();
+        ms.close();
     }
 
     @Test
@@ -67,7 +67,7 @@ public class MappedStoreTest {
             slice1.writeLong(2L);
             slice1.release();
 
-            ms1.free();
+            ms1.close();
         }
 
         {
@@ -79,7 +79,7 @@ public class MappedStoreTest {
 
             slice2.release();
 
-            ms2.free();
+            ms2.close();
         }
     }
 
@@ -104,7 +104,7 @@ public class MappedStoreTest {
     // Helpers
     // *************************************************************************
 
-    private static File getStoreFile(String fileName) {
+    static File getStoreFile(String fileName) {
         File file = new File(System.getProperty("java.io.tmpdir"),fileName);
         file.delete();
         file.deleteOnExit();

--- a/lang/src/test/java/net/openhft/lang/io/NativeBytesTest.java
+++ b/lang/src/test/java/net/openhft/lang/io/NativeBytesTest.java
@@ -110,7 +110,7 @@ public class NativeBytesTest {
     @Test
     public void testCapacity()   {
         assertEquals(SIZE, bytes.capacity());
-        assertEquals(10, new NativeBytes(0, 10).capacity());
+        assertEquals(10, new NativeBytes(100000, 100010).capacity());
     }
 
     @Test

--- a/lang/src/test/java/net/openhft/lang/io/ResizableMappedStoreTest.java
+++ b/lang/src/test/java/net/openhft/lang/io/ResizableMappedStoreTest.java
@@ -1,0 +1,70 @@
+/*
+ *     Copyright (C) 2015  higherfrequencytrading.com
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.openhft.lang.io;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+
+import org.junit.After;
+import org.junit.Test;
+
+public final class ResizableMappedStoreTest {
+    @After
+    public void tearDown() {
+        System.gc();
+    }
+
+    @Test
+    public void testResizableMappedStore() throws IOException {
+        File file = MappedStoreTest.getStoreFile("resizable-mapped-store.tmp");
+
+        final int smallSize = 1024, largeSize = 10 * smallSize;
+
+        {
+            ResizableMappedStore ms = new ResizableMappedStore(file, FileChannel.MapMode.READ_WRITE, smallSize);
+
+            DirectBytes slice1 = ms.bytes();
+            for (int i = 0; i < smallSize; ++i) {
+               slice1.writeByte(42);
+            }
+
+            ms.resize(largeSize);
+
+            DirectBytes slice2 = ms.bytes();
+            slice2.skipBytes(smallSize);
+            for (int i = smallSize; i < largeSize; ++i) {
+               slice2.writeByte(24);
+            }
+
+            ms.close();
+        }
+
+        assertEquals(largeSize, file.length());
+
+        {
+            ResizableMappedStore ms = new ResizableMappedStore(file, FileChannel.MapMode.READ_WRITE, file.length());
+            DirectBytes slice = ms.bytes();
+            assertEquals(42, slice.readByte(smallSize - 1));
+            assertEquals(24, slice.readByte(largeSize - 1));
+            slice.release();
+
+            ms.close();
+        }
+    }
+}

--- a/lang/src/test/java/net/openhft/lang/io/ResizeableMappedStoreTest.java
+++ b/lang/src/test/java/net/openhft/lang/io/ResizeableMappedStoreTest.java
@@ -1,0 +1,70 @@
+/*
+ *     Copyright (C) 2015  higherfrequencytrading.com
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.openhft.lang.io;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+
+import org.junit.After;
+import org.junit.Test;
+
+public final class ResizeableMappedStoreTest {
+    @After
+    public void tearDown() {
+        System.gc();
+    }
+
+    @Test
+    public void testResizableMappedStore() throws IOException {
+        File file = MappedStoreTest.getStoreFile("resizable-mapped-store.tmp");
+
+        final int smallSize = 1024, largeSize = 10 * smallSize;
+
+        {
+            ResizeableMappedStore ms = new ResizeableMappedStore(file, FileChannel.MapMode.READ_WRITE, smallSize);
+
+            DirectBytes slice1 = ms.bytes();
+            for (int i = 0; i < smallSize; ++i) {
+               slice1.writeByte(42);
+            }
+
+            ms.resize(largeSize);
+
+            DirectBytes slice2 = ms.bytes();
+            slice2.skipBytes(smallSize);
+            for (int i = smallSize; i < largeSize; ++i) {
+               slice2.writeByte(24);
+            }
+
+            ms.close();
+        }
+
+        assertEquals(largeSize, file.length());
+
+        {
+            ResizeableMappedStore ms = new ResizeableMappedStore(file, FileChannel.MapMode.READ_WRITE, file.length());
+            DirectBytes slice = ms.bytes();
+            assertEquals(42, slice.readByte(smallSize - 1));
+            assertEquals(24, slice.readByte(largeSize - 1));
+            slice.release();
+
+            ms.close();
+        }
+    }
+}

--- a/lang8/pom.xml
+++ b/lang8/pom.xml
@@ -38,7 +38,7 @@
                 <groupId>net.openhft</groupId>
                 <artifactId>third-party-bom</artifactId>
                 <type>pom</type>
-                <version>3.4.18</version>
+                <version>3.4.20</version>
                 <scope>import</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
The file-handle is kept open during the resize which means that it will work correcly even on "anonymous" files (files which have been deleted from the filesystem).

Warning! Access the Bytes from before the resize call after resize have been called can have undefined consequences (including a JVM crash) and it's the callers responsibility to ensure that that never happens.

This also disallows opening of zero length files (it seems to fail).

This also supersedes #62.