### PR TITLE
Add a version of MappedStore which can be resized

### DIFF
--- a/lang/src/main/java/net/openhft/lang/io/AbstractMappedStore.java
+++ b/lang/src/main/java/net/openhft/lang/io/AbstractMappedStore.java
@@ -1,0 +1,256 @@
+/*
+ *     Copyright (C) 2015  higherfrequencytrading.com
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.openhft.lang.io;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.channels.FileChannel;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import net.openhft.lang.io.serialization.ObjectSerializer;
+import net.openhft.lang.model.constraints.NotNull;
+import sun.misc.Cleaner;
+import sun.nio.ch.FileChannelImpl;
+
+abstract class AbstractMappedStore implements BytesStore, Closeable {
+    private static final int MAP_RO = 0;
+    private static final int MAP_RW = 1;
+    private static final int MAP_PV = 2;
+
+    // retain to prevent GC.
+    private final File file;
+    private final RandomAccessFile raf;
+    private final Cleaner cleaner;
+    private final AtomicInteger refCount = new AtomicInteger(1);
+    private final FileChannel.MapMode mode;
+    protected final MmapInfoHolder mmapInfoHolder;
+    private ObjectSerializer objectSerializer;
+
+    AbstractMappedStore(MmapInfoHolder mmapInfoHolder, File file, FileChannel.MapMode mode, long startInFile, long size, ObjectSerializer objectSerializer) throws IOException {
+        validateSize(size);
+        this.file = file;
+        this.mmapInfoHolder = mmapInfoHolder;
+        this.mmapInfoHolder.setSize(size);
+        this.objectSerializer = objectSerializer;
+        this.mode = mode;
+
+        try {
+            this.raf = new RandomAccessFile(file, accesModeFor(mode));
+            resizeIfNeeded(startInFile, size);
+            map(startInFile);
+            this.cleaner = Cleaner.create(this, new Unmapper(mmapInfoHolder, raf));
+        } catch (Exception e) {
+            throw wrap(e);
+        }
+    }
+
+    protected static void validateSize(long size) {
+        if (size <= 0 || size > 128L << 40) {
+            throw new IllegalArgumentException("invalid size: " + size);
+        }
+    }
+
+    protected final void resizeIfNeeded(long startInFile, long newSize) throws IOException {
+        if (file.getAbsolutePath().startsWith("/dev/")) {
+            return;
+        }
+        if (startInFile > 0) {
+            if (raf.length() >= startInFile + newSize) {
+                return;
+            }
+        } else if (startInFile == 0) {
+            if (raf.length() == newSize) {
+                return;
+            }
+        } else {
+            throw new IllegalArgumentException("Start offset in file needs to be positive: " + startInFile);
+        }
+        if (mode != FileChannel.MapMode.READ_WRITE) {
+            throw new IOException("Cannot resize file to " + newSize + " as mode is not READ_WRITE");
+        }
+
+        raf.setLength(startInFile + newSize);
+    }
+
+    protected final void map(long startInFile) throws IOException {
+        try {
+            mmapInfoHolder.setAddress(map0(raf.getChannel(), imodeFor(mode), startInFile, mmapInfoHolder.getSize()));
+        } catch (Exception e) {
+            throw wrap(e);
+        }
+    }
+
+    protected final void unmapAndSyncToDisk() throws IOException {
+        unmap0(mmapInfoHolder.getAddress(), mmapInfoHolder.getSize());
+        raf.getChannel().force(true);
+    }
+
+    private static long map0(FileChannel fileChannel, int imode, long start, long size) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        Method map0 = fileChannel.getClass().getDeclaredMethod("map0", int.class, long.class, long.class);
+        map0.setAccessible(true);
+        return (Long) map0.invoke(fileChannel, imode, start, size);
+    }
+
+    private static void unmap0(long address, long size) throws IOException {
+        try {
+            Method unmap0 = FileChannelImpl.class.getDeclaredMethod("unmap0", long.class, long.class);
+            unmap0.setAccessible(true);
+            unmap0.invoke(null, address, size);
+        } catch (Exception e) {
+            throw wrap(e);
+        }
+    }
+
+    private static IOException wrap(Throwable e) {
+        if (e instanceof InvocationTargetException)
+            e = e.getCause();
+        if (e instanceof IOException)
+            return (IOException) e;
+        return new IOException(e);
+    }
+
+    private static String accesModeFor(FileChannel.MapMode mode) {
+        return mode == FileChannel.MapMode.READ_WRITE ? "rw" : "r";
+    }
+
+    private static int imodeFor(FileChannel.MapMode mode) {
+        int imode = -1;
+        if (mode == FileChannel.MapMode.READ_ONLY)
+            imode = MAP_RO;
+        else if (mode == FileChannel.MapMode.READ_WRITE)
+            imode = MAP_RW;
+        else if (mode == FileChannel.MapMode.PRIVATE)
+            imode = MAP_PV;
+        assert (imode >= 0);
+        return imode;
+    }
+
+    @Override
+    public final ObjectSerializer objectSerializer() {
+        return objectSerializer;
+    }
+
+    @Override
+    public final long address() {
+        return mmapInfoHolder.getAddress();
+    }
+
+    @Override
+    public final long size() {
+        return mmapInfoHolder.getSize();
+    }
+
+    @Override
+    public final  void free() {
+        cleaner.clean();
+    }
+
+    @Override
+    public final  void close() {
+        free();
+    }
+
+    @NotNull
+    public final  DirectBytes bytes() {
+        return new DirectBytes(this, refCount);
+    }
+
+    @NotNull
+    public final  DirectBytes bytes(long offset, long length) {
+        return new DirectBytes(this, refCount, offset, length);
+    }
+
+    public final  File file() {
+        return file;
+    }
+
+    static final class MmapInfoHolder {
+        private long address, size;
+        private volatile boolean locked;
+
+        private void checkLock() {
+            if (locked) {
+                throw new IllegalStateException();
+            }
+        }
+
+        void lock() {
+            this.locked = true;
+        }
+
+        void setAddress(long address) {
+            checkLock();
+            this.address = address;
+        }
+
+        long getAddress() {
+            return address;
+        }
+
+        void setSize(long size) {
+            checkLock();
+            this.size = size;
+        }
+
+        long getSize() {
+            return size;
+        }
+    }
+
+    private static final class Unmapper implements Runnable {
+        private final MmapInfoHolder mmapInfoHolder;
+        private final RandomAccessFile raf;
+        /*
+         * This is not for synchronization (since calling this from multiple
+         * threads through .free / .close is an user error!) but rather to make
+         * sure that if an explicit cleanup was performed, the cleaner does not
+         * retry cleaning up the resources.
+         */
+        private volatile boolean cleanedUp;
+
+        Unmapper(MmapInfoHolder mmapInfo, RandomAccessFile raf) {
+            this.mmapInfoHolder = mmapInfo;
+            this.raf = raf;
+        }
+
+        public void run() {
+            if (cleanedUp) {
+                return;
+            }
+            cleanedUp = true;
+
+            try {
+                unmap0(mmapInfoHolder.getAddress(), mmapInfoHolder.getSize());
+                raf.getChannel().force(true);
+                // this also closes the underlying channel as per the documentation
+                raf.close();
+            } catch (IOException e) {
+                UnmapperLoggerHolder.LOGGER.log(Level.SEVERE,
+                    "An exception has occurred while cleaning up a MappedStore instance: " + e.getMessage(), e);
+            }
+        }
+    }
+
+    private static final class UnmapperLoggerHolder {
+        private static final Logger LOGGER = Logger.getLogger(Unmapper.class.getName());
+    }
+}

--- a/lang/src/main/java/net/openhft/lang/io/MappedStore.java
+++ b/lang/src/main/java/net/openhft/lang/io/MappedStore.java
@@ -21,202 +21,32 @@ import net.openhft.lang.io.serialization.BytesMarshallerFactory;
 import net.openhft.lang.io.serialization.JDKZObjectSerializer;
 import net.openhft.lang.io.serialization.ObjectSerializer;
 import net.openhft.lang.io.serialization.impl.VanillaBytesMarshallerFactory;
-import net.openhft.lang.model.constraints.NotNull;
-import sun.misc.Cleaner;
-import sun.nio.ch.FileChannelImpl;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.nio.channels.FileChannel;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
-public class MappedStore implements BytesStore, Closeable {
-
-    private static final int MAP_RO = 0;
-    private static final int MAP_RW = 1;
-    private static final int MAP_PV = 2;
-
-    // retain to prevent GC.
-    private final File file;
-    private final FileChannel fileChannel;
-    private final Cleaner cleaner;
-    private final long address;
-    private final AtomicInteger refCount = new AtomicInteger(1);
-    private final long size;
-    private ObjectSerializer objectSerializer;
-
+public class MappedStore extends AbstractMappedStore {
     public MappedStore(File file, FileChannel.MapMode mode, long size) throws IOException {
         this(file, mode, size, new VanillaBytesMarshallerFactory());
     }
 
     @Deprecated
     public MappedStore(File file, FileChannel.MapMode mode, long size,
-                       BytesMarshallerFactory bytesMarshallerFactory) throws IOException {
+            BytesMarshallerFactory bytesMarshallerFactory) throws IOException {
         this(file, mode, size, BytesMarshallableSerializer.create(
                 bytesMarshallerFactory, JDKZObjectSerializer.INSTANCE));
     }
 
     public MappedStore(File file, FileChannel.MapMode mode, long size,
-                       ObjectSerializer objectSerializer) throws IOException {
+            ObjectSerializer objectSerializer) throws IOException {
         this(file, mode, 0L, size, objectSerializer);
     }
 
     public MappedStore(File file, FileChannel.MapMode mode, long startInFile, long size,
-                       ObjectSerializer objectSerializer) throws IOException {
-        if (size < 0 || size > 128L << 40) {
-            throw new IllegalArgumentException("invalid size: " + size);
-        }
-
-        this.file = file;
-        this.size = size;
-        this.objectSerializer = objectSerializer;
-
-        try {
-            RandomAccessFile raf = new RandomAccessFile(file, accesModeFor(mode));
-            if ((raf.length() < startInFile + size || (startInFile == 0 && raf.length() != size))
-                    && !file.getAbsolutePath().startsWith("/dev/")) {
-                if (mode != FileChannel.MapMode.READ_WRITE) {
-                    throw new IOException(
-                            "Cannot resize file to " + size + " as mode is not READ_WRITE");
-                }
-
-                raf.setLength(startInFile + size);
-            }
-
-            this.fileChannel = raf.getChannel();
-            this.address = map0(fileChannel, imodeFor(mode), startInFile, size);
-            this.cleaner = Cleaner.create(this, new Unmapper(address, size, fileChannel));
-        } catch (Exception e) {
-            throw wrap(e);
-        }
-    }
-
-    private static long map0(FileChannel fileChannel, int imode, long start, long size)
-            throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-        Method map0 = fileChannel.getClass().getDeclaredMethod(
-                "map0", int.class, long.class, long.class);
-        map0.setAccessible(true);
-        return (Long) map0.invoke(fileChannel, imode, start, size);
-    }
-
-    private static void unmap0(long address, long size) throws IOException {
-        try {
-            Method unmap0 = FileChannelImpl.class.getDeclaredMethod(
-                    "unmap0", long.class, long.class);
-            unmap0.setAccessible(true);
-            unmap0.invoke(null, address, size);
-        } catch (Exception e) {
-            throw wrap(e);
-        }
-    }
-
-    private static IOException wrap(Throwable e) {
-        if (e instanceof InvocationTargetException)
-            e = e.getCause();
-        if (e instanceof IOException)
-            return (IOException) e;
-        return new IOException(e);
-    }
-
-    private static String accesModeFor(FileChannel.MapMode mode) {
-        return mode == FileChannel.MapMode.READ_WRITE ? "rw" : "r";
-    }
-
-    private static int imodeFor(FileChannel.MapMode mode) {
-        int imode = -1;
-        if (mode == FileChannel.MapMode.READ_ONLY)
-            imode = MAP_RO;
-        else if (mode == FileChannel.MapMode.READ_WRITE)
-            imode = MAP_RW;
-        else if (mode == FileChannel.MapMode.PRIVATE)
-            imode = MAP_PV;
-        assert (imode >= 0);
-        return imode;
-    }
-
-    @Override
-    public ObjectSerializer objectSerializer() {
-        return objectSerializer;
-    }
-
-    @Override
-    public long address() {
-        return address;
-    }
-
-    @Override
-    public long size() {
-        return size;
-    }
-
-    @Override
-    public void free() {
-        cleaner.clean();
-    }
-
-    @Override
-    public void close() {
-        free();
-    }
-
-    @NotNull
-    public DirectBytes bytes() {
-        return new DirectBytes(this, refCount);
-    }
-
-    @NotNull
-    public DirectBytes bytes(long offset, long length) {
-        return new DirectBytes(this, refCount, offset, length);
-    }
-
-    public File file() {
-        return file;
-    }
-
-    private static final class Unmapper implements Runnable {
-        private final long size;
-        private final FileChannel channel;
-        /*
-         * This is not for synchronization (since calling this from multiple
-         * threads through .free / .close is an user error!) but rather to make
-         * sure that if an explicit cleanup was performed, the cleaner does not
-         * retry cleaning up the resources.
-         */
-        private volatile long address;
-
-        Unmapper(long address, long size, FileChannel channel) {
-            assert (address != 0);
-            this.address = address;
-            this.size = size;
-            this.channel = channel;
-        }
-
-        public void run() {
-            if (address == 0)
-                return;
-
-            try {
-                unmap0(address, size);
-                address = 0;
-
-                channel.force(true);
-                channel.close();
-            } catch (IOException e) {
-                UnmapperLoggerHolder.LOGGER.log(Level.SEVERE,
-                    "An exception has occurred while cleaning up a MappedStore instance: " +
-                            e.getMessage(), e);
-            }
-        }
-
-        private static final class UnmapperLoggerHolder {
-            private static final Logger LOGGER = Logger.getLogger(Unmapper.class.getName());
-        }
+            ObjectSerializer objectSerializer) throws IOException {
+        super(new MmapInfoHolder(), file, mode, startInFile, size, objectSerializer);
+        mmapInfoHolder.lock();
     }
 }
 

--- a/lang/src/main/java/net/openhft/lang/io/ResizeableMappedStore.java
+++ b/lang/src/main/java/net/openhft/lang/io/ResizeableMappedStore.java
@@ -1,0 +1,54 @@
+/*
+ *     Copyright (C) 2015  higherfrequencytrading.com
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.openhft.lang.io;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+
+import net.openhft.lang.io.serialization.BytesMarshallableSerializer;
+import net.openhft.lang.io.serialization.JDKZObjectSerializer;
+import net.openhft.lang.io.serialization.ObjectSerializer;
+import net.openhft.lang.io.serialization.impl.VanillaBytesMarshallerFactory;
+
+public final class ResizeableMappedStore extends AbstractMappedStore {
+    public ResizeableMappedStore(File file, FileChannel.MapMode mode, long size) throws IOException {
+        this(file, mode, size, BytesMarshallableSerializer.create(new VanillaBytesMarshallerFactory(), JDKZObjectSerializer.INSTANCE));
+    }
+
+    public ResizeableMappedStore(File file, FileChannel.MapMode mode, long size, ObjectSerializer objectSerializer) throws IOException {
+        super(new MmapInfoHolder(), file, mode, 0L, size, objectSerializer);
+    }
+
+
+    /**
+     * Resizes the underlying file and re-maps it. Warning! After this call
+     * instances of {@link Bytes} obtained through {@link #bytes()} or
+     * {@link #bytes(long, long)} are invalid and using them can lead to reading
+     * arbitrary data or JVM crash! It is the callers responsibility to ensure
+     * that these instances are not used after the method call.
+     *
+     * @param newSize
+     * @throws IOException
+     */
+    public void resize(long newSize) throws IOException {
+        validateSize(newSize);
+        unmapAndSyncToDisk();
+        resizeIfNeeded(0L, newSize);
+        this.mmapInfoHolder.setSize(newSize);
+        map(0L);
+    }
+}

--- a/lang/src/test/java/net/openhft/lang/io/ResizeableMappedStoreTest.java
+++ b/lang/src/test/java/net/openhft/lang/io/ResizeableMappedStoreTest.java
@@ -1,0 +1,70 @@
+/*
+ *     Copyright (C) 2015  higherfrequencytrading.com
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.openhft.lang.io;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+
+import org.junit.After;
+import org.junit.Test;
+
+public final class ResizeableMappedStoreTest {
+    @After
+    public void tearDown() {
+        System.gc();
+    }
+
+    @Test
+    public void testResizableMappedStore() throws IOException {
+        File file = MappedStoreTest.getStoreFile("resizable-mapped-store.tmp");
+
+        final int smallSize = 1024, largeSize = 10 * smallSize;
+
+        {
+            ResizeableMappedStore ms = new ResizeableMappedStore(file, FileChannel.MapMode.READ_WRITE, smallSize);
+
+            DirectBytes slice1 = ms.bytes();
+            for (int i = 0; i < smallSize; ++i) {
+               slice1.writeByte(42);
+            }
+
+            ms.resize(largeSize);
+
+            DirectBytes slice2 = ms.bytes();
+            slice2.skipBytes(smallSize);
+            for (int i = smallSize; i < largeSize; ++i) {
+               slice2.writeByte(24);
+            }
+
+            ms.close();
+        }
+
+        assertEquals(largeSize, file.length());
+
+        {
+            ResizeableMappedStore ms = new ResizeableMappedStore(file, FileChannel.MapMode.READ_WRITE, file.length());
+            DirectBytes slice = ms.bytes();
+            assertEquals(42, slice.readByte(smallSize - 1));
+            assertEquals(24, slice.readByte(largeSize - 1));
+            slice.release();
+
+            ms.close();
+        }
+    }
+}


### PR DESCRIPTION
The file-handle is kept open during the resize which means that it will work correcly even on "anonymous" files (files which have been deleted from the filesystem).

Warning! Access the Bytes from before the resize call after resize have been called can have undefined consequences (including a JVM crash) and it's the callers responsibility to ensure that that never happens.

This also disallows opening of zero length files (because they fail anyway when trying to mmapping them).