### PR TITLE
Update AbstractBytes.java

### DIFF
--- a/lang/src/main/java/net/openhft/lang/io/AbstractBytes.java
+++ b/lang/src/main/java/net/openhft/lang/io/AbstractBytes.java
@@ -2184,7 +2184,7 @@ public abstract class AbstractBytes implements Bytes {
             return;
         }
         if (e instanceof Enum) {
-            write8bitText(e.toString());
+            write8bitText(e.name());
             return;
         }
 


### PR DESCRIPTION
Use Enum.name() instead of Enum.toString() because toString is not final and can be overriden.