### PR TITLE
 "static final" arrays should be "private"

### DIFF
--- a/lang-sandbox/src/main/java/net/openhft/lang/arena/MappedArena.java
+++ b/lang-sandbox/src/main/java/net/openhft/lang/arena/MappedArena.java
@@ -29,7 +29,7 @@ import java.nio.channels.FileChannel;
  * Created by peter.lawrey on 22/06/14.
  */
 public class MappedArena implements Arena {
-    static final byte[] MAGIC = "Arena001".getBytes();
+    private static final byte[] MAGIC = "Arena001".getBytes();
     static final int MAGIC_OFFSET = 0;
     static final int LOCK_OFFSET = MAGIC_OFFSET + 8;
     static final int ALLOCATE_SIZE_OFFSET = LOCK_OFFSET + 8;

--- a/lang-sandbox/src/main/java/net/openhft/lang/io/OffHeapReadWriteLock.java
+++ b/lang-sandbox/src/main/java/net/openhft/lang/io/OffHeapReadWriteLock.java
@@ -44,7 +44,7 @@ public class OffHeapReadWriteLock {
         return bytes.compareAndSwapLong(offset, lock0, lock2);
     }
 
-    static final String[] RW_MODES = {"none", "read", "write"};
+    private static final String[] RW_MODES = {"none", "read", "write"};
 
     public ReadLock readLock() {
         return readLock;

--- a/lang/src/main/java/net/openhft/lang/io/AbstractBytes.java
+++ b/lang/src/main/java/net/openhft/lang/io/AbstractBytes.java
@@ -61,7 +61,7 @@ public abstract class AbstractBytes implements Bytes {
     static final long RW_WRITE_WAITING = 1L << RW_LOCK_LIMIT;
     static final long RW_WRITE_LOCKED = 1L << 2 * RW_LOCK_LIMIT;
     static final int RW_LOCK_MASK = (1 << RW_LOCK_LIMIT) - 1;
-    static final char[] HEXI_DECIMAL = "0123456789ABCDEF".toCharArray();
+    private static final char[] HEXI_DECIMAL = "0123456789ABCDEF".toCharArray();
     private static final long BUSY_LOCK_LIMIT = 20L * 1000 * 1000 * 1000;
     private static final int INT_LOCK_MASK;
     private static final int UNSIGNED_BYTE_MASK = 0xFF;

--- a/lang/src/test/java/net/openhft/lang/io/BigDecimalVsDoubleMain.java
+++ b/lang/src/test/java/net/openhft/lang/io/BigDecimalVsDoubleMain.java
@@ -21,8 +21,8 @@ import java.nio.ByteBuffer;
 
 public class BigDecimalVsDoubleMain {
 
-    public static final String[] NUMBER = {"1000000", "1.1", "1.23456", "12345.67890"};
-    public static final Bytes[] IN_BYTES = new Bytes[NUMBER.length];
+    private static final String[] NUMBER = {"1000000", "1.1", "1.23456", "12345.67890"};
+    private static final Bytes[] IN_BYTES = new Bytes[NUMBER.length];
     public static final Bytes OUT_BYTES;
 
     static {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1873 - “ "static final" arrays should be "private" ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1873
Please let me know if you have any questions.
Ayman Abdelghany.
